### PR TITLE
resolving issue 43 - Colocar mínimo e máximo nos campos

### DIFF
--- a/src/main/resources/openapi/openapi.yaml
+++ b/src/main/resources/openapi/openapi.yaml
@@ -476,22 +476,32 @@ components:
           type: string
           description: Nome completo do usuário.
           example: João Silva
+          minLength: 1
+          maxLength: 100
         email:
           type: string
           description: Endereço de e-mail único do usuário.
           example: joao.silva@example.com
+          minLength: 1
+          maxLength: 255
         cpf:
           type: string
           description: Cadastro de Pessoa Física (CPF) do usuário. Deve ser único.
           example: '286.084.030-30'
+          minLength: 11
+          maxLength: 14
         login:
           type: string
           description: Nome de usuário para login. Deve ser único.
           example: joaosilva123
+          minLength: 1
+          maxLength: 50
         password:
           type: string
           description: Senha do usuário.
           example: MyStrongPassword123!
+          minLength: 8
+          maxLength: 64
         role:
           type: string
           description: Papel do usuário no sistema (OWNER ou CUSTOMER).


### PR DESCRIPTION
Ajustando a capacidade mínima e máxima do CreateUserRequest, alterando o openapi.yaml, refletindo corretamente no postman de acordo com o ErrorResponse: 

<img width="1535" height="826" alt="image" src="https://github.com/user-attachments/assets/02842d50-1a01-45f3-ad08-ed6afd86f4da" />
