### PR TITLE
fix: corrige validação de endereço não vinculado ao usuário

### DIFF
--- a/src/main/java/com/fiap/techchallenge/application/ports/out/user/AddressUserRepository.java
+++ b/src/main/java/com/fiap/techchallenge/application/ports/out/user/AddressUserRepository.java
@@ -13,4 +13,6 @@ public interface AddressUserRepository {
     List<Address> listAll(UUID userId);
 
     Address update(UpdateAddress updateAddress, UUID userId, UUID addressId);
+
+    void delete(UUID userId, UUID addressId);
 }

--- a/src/main/java/com/fiap/techchallenge/application/services/user/impl/AddressUserUseCaseImpl.java
+++ b/src/main/java/com/fiap/techchallenge/application/services/user/impl/AddressUserUseCaseImpl.java
@@ -36,6 +36,6 @@ public class AddressUserUseCaseImpl implements AddressUserUseCase {
 
     @Override
     public void delete(UUID idUSer, UUID idAddress) {
-
+        this.addressUserRepository.delete(idUSer, idAddress);
     }
 }

--- a/src/main/java/com/fiap/techchallenge/domain/exceptions/AddressNotLinkedToUserException.java
+++ b/src/main/java/com/fiap/techchallenge/domain/exceptions/AddressNotLinkedToUserException.java
@@ -1,0 +1,7 @@
+package com.fiap.techchallenge.domain.exceptions;
+
+public class AddressNotLinkedToUserException extends RuntimeException {
+    public AddressNotLinkedToUserException() {
+        super("Você não está vinculado a esse endereço.");
+    }
+}

--- a/src/main/java/com/fiap/techchallenge/domain/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/fiap/techchallenge/domain/exceptions/GlobalExceptionHandler.java
@@ -297,7 +297,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(EmailAlreadyExistsException.class)
     public ResponseEntity<ErrorResponse> handleEmailAlreadyExistsException(EmailAlreadyExistsException ex,
-                                                                           HttpServletRequest request) {
+            HttpServletRequest request) {
 
         ErrorResponse errorResponse = new ErrorResponse();
         errorResponse.setMessage(ex.getMessage());
@@ -310,7 +310,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(UsernameAlreadyExistsException.class)
     public ResponseEntity<ErrorResponse> handleUsernameAlreadyExistsException(UsernameAlreadyExistsException ex,
-                                                                              HttpServletRequest request) {
+            HttpServletRequest request) {
 
         ErrorResponse errorResponse = new ErrorResponse();
         errorResponse.setMessage(ex.getMessage());
@@ -323,7 +323,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(InvalidCpfException.class)
     public ResponseEntity<ErrorResponse> handleInvalidCpfExceptionException(InvalidCpfException ex,
-                                                                            HttpServletRequest request) {
+            HttpServletRequest request) {
 
         ErrorResponse errorResponse = new ErrorResponse();
         errorResponse.setMessage(ex.getMessage());
@@ -336,7 +336,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(InvalidEmailPatternException.class)
     public ResponseEntity<ErrorResponse> handleInvalidEmailPatternException(InvalidEmailPatternException ex,
-                                                                            HttpServletRequest request) {
+            HttpServletRequest request) {
         ErrorResponse errorResponse = new ErrorResponse();
         errorResponse.setMessage(ex.getMessage());
         errorResponse.setCode("INVALID_EMAIL");
@@ -349,7 +349,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(CustomAuthenticationException.class)
     public ResponseEntity<ErrorResponse> handleCustomAuthenticationException(CustomAuthenticationException ex,
-                                                                             HttpServletRequest request) {
+            HttpServletRequest request) {
 
         ErrorResponse errorResponse = new ErrorResponse();
         errorResponse.setMessage("Usuário ou senha incorretos");
@@ -362,8 +362,7 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(UserNotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex,
-                                                            HttpServletRequest request) {
+    public ResponseEntity<ErrorResponse> handleUserNotFound(UserNotFoundException ex, HttpServletRequest request) {
         ErrorResponse errorResponse = new ErrorResponse();
         errorResponse.setMessage(ex.getMessage());
         errorResponse.setCode("USER_NOT_FOUND");
@@ -372,6 +371,30 @@ public class GlobalExceptionHandler {
 
         logger.warn("E-mail inválido: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(AddressNotFoundException.class)
+    public ResponseEntity<ErrorResponse> handleAddressNotFound(AddressNotFoundException ex, HttpServletRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse();
+        errorResponse.setMessage("Address not found for the specified user.");
+        errorResponse.setCode("ADDRESS_NOT_FOUND");
+        errorResponse.setStatus(HttpStatus.NOT_FOUND.value());
+        errorResponse.setPath(request.getRequestURI());
+
+        logger.warn("Address not found: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(errorResponse);
+    }
+
+    @ExceptionHandler(AddressNotLinkedToUserException.class)
+    public ResponseEntity<ErrorResponse> handleAddressNotLinkedToUser(AddressNotLinkedToUserException ex, HttpServletRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse();
+        errorResponse.setMessage("You are not linked to this address.");
+        errorResponse.setCode("ADDRESS_NOT_LINKED_TO_USER");
+        errorResponse.setStatus(HttpStatus.FORBIDDEN.value());
+        errorResponse.setPath(request.getRequestURI());
+
+        logger.warn("Address not linked to user: {}", ex.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
     }
 
 }

--- a/src/main/java/com/fiap/techchallenge/infrastructure/adapters/in/web/AddressUserApiImpl.java
+++ b/src/main/java/com/fiap/techchallenge/infrastructure/adapters/in/web/AddressUserApiImpl.java
@@ -60,7 +60,8 @@ public class AddressUserApiImpl implements AddressesApi {
 
     @Override
     public ResponseEntity<Void> deleteAddressForUser(UUID userId, UUID addressId) {
-        return null;
+        addressUserUseCase.delete(userId, addressId);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/fiap/techchallenge/infrastructure/adapters/out/persistence/user/AddressUserDataSource.java
+++ b/src/main/java/com/fiap/techchallenge/infrastructure/adapters/out/persistence/user/AddressUserDataSource.java
@@ -5,6 +5,7 @@ import com.fiap.techchallenge.application.ports.in.user.dtos.CreateAddress;
 import com.fiap.techchallenge.application.ports.in.user.dtos.UpdateAddress;
 import com.fiap.techchallenge.application.ports.out.user.AddressUserRepository;
 import com.fiap.techchallenge.domain.exceptions.AddressNotFoundException;
+import com.fiap.techchallenge.domain.exceptions.AddressNotLinkedToUserException;
 import com.fiap.techchallenge.domain.exceptions.UserNotFoundException;
 import com.fiap.techchallenge.infrastructure.adapters.in.mapper.AddressUserApiMapper;
 import com.fiap.techchallenge.infrastructure.adapters.out.persistence.user.entities.AddressUserEntity;
@@ -68,6 +69,20 @@ public class AddressUserDataSource implements AddressUserRepository {
         AddressUserEntity saved = addressUserJpaRepository.save(entity);
 
         return ADDRESS_USER_MAPPER.mapToAddress(saved);
+    }
+
+    @Override
+    public void delete(UUID userId, UUID addressId) {
+        userJpaRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+
+        AddressUserEntity entity = addressUserJpaRepository.findById(addressId)
+                .orElseThrow(AddressNotFoundException::new);
+
+        if (!entity.getUser().getId().equals(userId)) {
+            throw new AddressNotLinkedToUserException();
+        }
+
+        addressUserJpaRepository.delete(entity);
     }
 
 }

--- a/src/main/java/com/fiap/techchallenge/infrastructure/adapters/out/persistence/user/UserDataSource.java
+++ b/src/main/java/com/fiap/techchallenge/infrastructure/adapters/out/persistence/user/UserDataSource.java
@@ -96,7 +96,8 @@ public class UserDataSource implements UserRepository {
 
     @Override
     public void changePassword(ChangePassword changePassword) {
-        UserEntity savedEntity = jpaRepository.findById(changePassword.getIdUser()).orElseThrow(UserNotFoundException::new);
+        UserEntity savedEntity = jpaRepository.findById(changePassword.getIdUser())
+                .orElseThrow(UserNotFoundException::new);
 
         savedEntity.setPassword(changePassword.getNewPassword());
         jpaRepository.save(savedEntity);


### PR DESCRIPTION
Implementa validação para garantir que apenas endereços vinculados ao usuário possam ser excluídos ou atualizados, diferenciando casos de endereço inexistente e não associado.

- Adicionando tratativa quando não há endereço associado a um usuário:

<img width="886" height="447" alt="image" src="https://github.com/user-attachments/assets/7ca8d365-87d5-4500-96d3-0c17cd427ec6" />

- Tentativa de deletar um endereço de outro usuário: 

<img width="886" height="426" alt="image" src="https://github.com/user-attachments/assets/8e790e2a-ead5-4373-9f66-56ef25920d25" />

- Deletando normalmente:

<img width="886" height="400" alt="image" src="https://github.com/user-attachments/assets/e2454129-2883-4126-8a3f-1b1711f08052" />

