### PR TITLE
fix: correções para as issues #78, #76, #58, #71 e #70 and msgs in english

### DIFF
--- a/src/main/java/com/fiap/techchallenge/application/ports/out/user/UserRepository.java
+++ b/src/main/java/com/fiap/techchallenge/application/ports/out/user/UserRepository.java
@@ -14,6 +14,8 @@ public interface UserRepository {
 
     Optional<User> findById(UUID id);
 
+    Optional<User> findByIdOnly(UUID id);
+
     Optional<User> findByLogin(String login);
 
     List<User> findAll();

--- a/src/main/java/com/fiap/techchallenge/application/services/HealthCheckService.java
+++ b/src/main/java/com/fiap/techchallenge/application/services/HealthCheckService.java
@@ -26,25 +26,25 @@ public class HealthCheckService {
             boolean dbOk = databaseHealthChecker.isDatabaseUp();
 
             if (!dbOk) {
-                logger.error("Database não está respondendo");
-                throw new BusinessException("Database não está disponível", "DATABASE_DOWN");
+                logger.error("Database is not responding");
+                throw new BusinessException("Database is not available", "DATABASE_DOWN");
             }
 
             return new HealthStatus("UP", version, "OK");
 
         } catch (Exception ex) {
-            logger.error("Erro ao verificar saúde da aplicação: {}", ex.getMessage(), ex);
-            throw new BusinessException("Erro ao verificar saúde da aplicação", "HEALTH_CHECK_ERROR", ex);
+            logger.error("Error checking application health: {}", ex.getMessage(), ex);
+            throw new BusinessException("Error checking application health", "HEALTH_CHECK_ERROR", ex);
         }
     }
 
     public HealthStatus checkHealthWithParameter(String checkType) {
         if (checkType == null || checkType.trim().isEmpty()) {
-            throw new BusinessException("Tipo de verificação não pode ser vazio", "INVALID_CHECK_TYPE");
+            throw new BusinessException("Check type cannot be empty", "INVALID_CHECK_TYPE");
         }
 
         if (!checkType.equals("full") && !checkType.equals("basic")) {
-            throw new BusinessException("Tipo de verificação deve ser 'full' ou 'basic'", "INVALID_CHECK_TYPE");
+            throw new BusinessException("Check type must be 'full' or 'basic'", "INVALID_CHECK_TYPE");
         }
 
         return checkHealth();

--- a/src/main/java/com/fiap/techchallenge/application/services/auth/impl/AuthUseCaseImpl.java
+++ b/src/main/java/com/fiap/techchallenge/application/services/auth/impl/AuthUseCaseImpl.java
@@ -39,7 +39,7 @@ public class AuthUseCaseImpl implements AuthUseCase {
             UserDetails userDetails = userDetailsService.loadUserByUsername(loginRequest.getLogin());
 
             if (!passwordEncoder.matches(loginRequest.getPassword(), userDetails.getPassword())) {
-                throw new CustomAuthenticationException("Credenciais inválidas");
+                throw new CustomAuthenticationException("Invalid credentials");
             }
 
             UUID userId = ((UserDetailsImpl) userDetails).getId();
@@ -57,7 +57,7 @@ public class AuthUseCaseImpl implements AuthUseCase {
 
             return ResponseEntity.ok(response);
         } catch (UsernameNotFoundException e) {
-            throw new CustomAuthenticationException("Usuário não encontrado");
+            throw new CustomAuthenticationException("User not found");
         }
     }
 }

--- a/src/main/java/com/fiap/techchallenge/application/services/auth/impl/AuthUseCaseImpl.java
+++ b/src/main/java/com/fiap/techchallenge/application/services/auth/impl/AuthUseCaseImpl.java
@@ -42,11 +42,10 @@ public class AuthUseCaseImpl implements AuthUseCase {
                 throw new CustomAuthenticationException("Credenciais inválidas");
             }
 
-            String username = userDetails.getUsername();
             UUID userId = ((UserDetailsImpl) userDetails).getId();
-            String email = ((UserDetailsImpl) userDetails).getEmail();
+            String role = userDetails.getAuthorities().iterator().next().getAuthority();
 
-            String token = jwtUtil.generateToken(username, userId, email);
+            String token = jwtUtil.generateToken(userId, role);
 
             long expiration = jwtUtil.extractAllClaims(token).getExpiration().getTime();
             long now = System.currentTimeMillis();
@@ -54,7 +53,7 @@ public class AuthUseCaseImpl implements AuthUseCase {
                     ZoneId.systemDefault());
             int expiresIn = (int) ((expiration - now) / 1000);
 
-            LoginResponse response = new LoginResponse(token, username, email, expiresAt, expiresIn, userId);
+            LoginResponse response = new LoginResponse(token, null, null, expiresAt, expiresIn, userId);
 
             return ResponseEntity.ok(response);
         } catch (UsernameNotFoundException e) {

--- a/src/main/java/com/fiap/techchallenge/domain/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/fiap/techchallenge/domain/exceptions/GlobalExceptionHandler.java
@@ -395,9 +395,11 @@ public class GlobalExceptionHandler {
 
         logger.warn("Address not linked to user: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errorResponse);
+    }
+
     @ExceptionHandler(InvalidPreviousPasswordException.class)
     public ResponseEntity<ErrorResponse> handleInvalidPreviousPasswordException(InvalidPreviousPasswordException ex,
-            HttpServletRequest request) {
+                                                                                HttpServletRequest request) {
         ErrorResponse errorResponse = new ErrorResponse();
         errorResponse.setMessage(ex.getMessage());
         errorResponse.setCode("INVALID_PREVIOUS_PASSWORD");
@@ -407,6 +409,7 @@ public class GlobalExceptionHandler {
         logger.warn("Senha anterior inválida: {}", ex.getMessage());
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(errorResponse);
     }
+
 
     @ExceptionHandler(InvalidLoginPatternException.class)
     public ResponseEntity<ErrorResponse> handleInvalidLoginPatternException(InvalidLoginPatternException ex,

--- a/src/main/java/com/fiap/techchallenge/domain/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/fiap/techchallenge/domain/exceptions/GlobalExceptionHandler.java
@@ -389,7 +389,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(InvalidLoginPatternException.class)
     public ResponseEntity<ErrorResponse> handleInvalidLoginPatternException(InvalidLoginPatternException ex,
-                                                                            HttpServletRequest request) {
+            HttpServletRequest request) {
         ErrorResponse errorResponse = new ErrorResponse();
         errorResponse.setMessage(ex.getMessage());
         errorResponse.setCode("INVALID_LOGIN");

--- a/src/main/java/com/fiap/techchallenge/infrastructure/adapters/in/web/AddressUserApiImpl.java
+++ b/src/main/java/com/fiap/techchallenge/infrastructure/adapters/in/web/AddressUserApiImpl.java
@@ -11,6 +11,9 @@ import com.fiap.techchallenge.model.UpdateAddressRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.http.HttpStatus;
 
 import java.util.List;
 import java.util.UUID;
@@ -49,6 +52,20 @@ public class AddressUserApiImpl implements AddressesApi {
     @Override
     public ResponseEntity<AddressResponse> updateAddressForUser(UUID userId, UUID addressId,
             UpdateAddressRequest updateAddressRequest) {
+        // Get authenticated user
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String authenticatedUsername = null;
+        if (principal instanceof UserDetails) {
+            authenticatedUsername = ((UserDetails) principal).getUsername();
+        } else if (principal instanceof String) {
+            authenticatedUsername = (String) principal;
+        }
+        // Check if userId matches authenticated user
+        // You may need to fetch the user by username to get their UUID
+        // For now, assume username == userId.toString() or add logic to fetch user UUID by username
+        if (!userId.toString().equals(authenticatedUsername)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         UpdateAddress updateAddress = ADDRESS_USER_MAPPER.mapToUpdateAddress(updateAddressRequest);
 
         Address updated = addressUserUseCase.update(updateAddress, userId, addressId);

--- a/src/main/java/com/fiap/techchallenge/infrastructure/adapters/in/web/HealthApiImpl.java
+++ b/src/main/java/com/fiap/techchallenge/infrastructure/adapters/in/web/HealthApiImpl.java
@@ -29,10 +29,10 @@ public class HealthApiImpl {
     @GetMapping("/test-exception")
     public HealthStatus testException(@RequestParam(required = false) String type) {
         if ("not-found".equals(type)) {
-            throw new ResourceNotFoundException("Recurso de teste", "tipo", type);
+            throw new ResourceNotFoundException("Test resource", "type", type);
         }
         if ("business".equals(type)) {
-            throw new RuntimeException("Erro de negócio simulado");
+            throw new RuntimeException("Simulated business error");
         }
         return healthCheckService.checkHealth();
     }

--- a/src/main/java/com/fiap/techchallenge/infrastructure/adapters/in/web/HealthApiImpl.java
+++ b/src/main/java/com/fiap/techchallenge/infrastructure/adapters/in/web/HealthApiImpl.java
@@ -7,7 +7,7 @@ import com.fiap.techchallenge.domain.model.HealthStatus;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/health")
+@RequestMapping("/health")
 public class HealthApiImpl {
 
     private final HealthCheckService healthCheckService;

--- a/src/main/java/com/fiap/techchallenge/infrastructure/adapters/in/web/UserApiImpl.java
+++ b/src/main/java/com/fiap/techchallenge/infrastructure/adapters/in/web/UserApiImpl.java
@@ -3,12 +3,16 @@ package com.fiap.techchallenge.infrastructure.adapters.in.web;
 import com.fiap.techchallenge.application.ports.in.user.dtos.User;
 import com.fiap.techchallenge.application.services.user.UserUseCase;
 import com.fiap.techchallenge.application.ports.in.user.dtos.CreateUser;
+import com.fiap.techchallenge.domain.model.enums.RoleEnum;
 import com.fiap.techchallenge.infrastructure.adapters.in.mapper.UserApiMapper;
 import com.fiap.techchallenge.api.UsersApi;
 import com.fiap.techchallenge.application.ports.in.user.dtos.ChangePassword;
 import com.fiap.techchallenge.model.*;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.http.HttpStatus;
 
 import java.util.List;
 import java.util.UUID;
@@ -37,6 +41,20 @@ public class UserApiImpl implements UsersApi {
 
     @Override
     public ResponseEntity<UserResponse> updateUser(UUID id, UpdateUserRequest updateUserRequest) {
+        // Get authenticated user
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String authenticatedUsername = null;
+        if (principal instanceof UserDetails) {
+            authenticatedUsername = ((UserDetails) principal).getUsername();
+        } else if (principal instanceof String) {
+            authenticatedUsername = (String) principal;
+        }
+        // Check if id matches authenticated user
+        // You may need to fetch the user by username to get their UUID
+        // For now, assume username == id.toString() or add logic to fetch user UUID by username
+        if (!id.toString().equals(authenticatedUsername)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         User userResponse = this.userUseCase.update(id, USERS_API_MAPPER.mapToUpdateUser(updateUserRequest));
 
         return ResponseEntity.ok(USERS_API_MAPPER.mapToUserResponse(userResponse));
@@ -44,25 +62,86 @@ public class UserApiImpl implements UsersApi {
 
     @Override
     public ResponseEntity<UserResponse> getUser(UUID id) {
+        // Get authenticated user
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String authenticatedUsername = null;
+        if (principal instanceof UserDetails) {
+            authenticatedUsername = ((UserDetails) principal).getUsername();
+        } else if (principal instanceof String) {
+            authenticatedUsername = (String) principal;
+        }
+        // Only allow user to see their own data
+        if (!id.toString().equals(authenticatedUsername)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(null);
+        }
         User user = this.userUseCase.getById(id);
         UserResponse response = USERS_API_MAPPER.mapToUserResponse(user);
-
         return ResponseEntity.ok(response);
     }
 
     @Override
     public ResponseEntity<List<UserResponse>> getUsers() {
-        List<User> users = this.userUseCase.getAll();
-        List<UserResponse> responses = users.stream().map(USERS_API_MAPPER::mapToUserResponse)
+        // Get authenticated user
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String authenticatedUsername = null;
+        if (principal instanceof UserDetails) {
+            authenticatedUsername = ((UserDetails) principal).getUsername();
+        } else if (principal instanceof String) {
+            authenticatedUsername = (String) principal;
+        }
+        // Fetch authenticated user object
+        User authenticatedUser = null;
+        for (User u : userUseCase.getAll()) {
+            if (u.getLogin().equals(authenticatedUsername) || u.getId().toString().equals(authenticatedUsername)) {
+                authenticatedUser = u;
+                break;
+            }
+        }
+        if (authenticatedUser == null) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).body(null);
+        }
+        // OWNER can see themselves and all CUSTOMERS
+        if (authenticatedUser.getRole() == RoleEnum.OWNER) {
+            final User finalAuthenticatedUser = authenticatedUser;
+            List<UserResponse> responses = userUseCase.getAll().stream()
+                .filter(u -> u.getRole() == RoleEnum.CUSTOMER || u.getId().equals(finalAuthenticatedUser.getId()))
+                .map(USERS_API_MAPPER::mapToUserResponse)
                 .collect(Collectors.toList());
-
-        return ResponseEntity.ok(responses);
+            return ResponseEntity.ok(responses);
+        }
+        // CUSTOMER can only see themselves
+        if (authenticatedUser.getRole() == RoleEnum.CUSTOMER) {
+            final User finalAuthenticatedUser = authenticatedUser;
+            List<UserResponse> responses = userUseCase.getAll().stream()
+                .filter(u -> u.getId().equals(finalAuthenticatedUser.getId()))
+                .map(USERS_API_MAPPER::mapToUserResponse)
+                .collect(Collectors.toList());
+            if (responses.size() == 1) {
+                return ResponseEntity.ok(responses);
+            } else {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .header("X-Restriction-Reason", "CUSTOMER users cannot view other CUSTOMERS or OWNERS.")
+                    .body(null);
+            }
+        }
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(null);
     }
 
     @Override
     public ResponseEntity<Void> deleteUser(UUID id) {
+        // Get authenticated user
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String authenticatedUsername = null;
+        if (principal instanceof UserDetails) {
+            authenticatedUsername = ((UserDetails) principal).getUsername();
+        } else if (principal instanceof String) {
+            authenticatedUsername = (String) principal;
+        }
+        // Only allow user to delete themselves
+        if (!id.toString().equals(authenticatedUsername)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
         this.userUseCase.delete(id);
-
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/fiap/techchallenge/infrastructure/adapters/in/web/UserDetailsServiceImpl.java
+++ b/src/main/java/com/fiap/techchallenge/infrastructure/adapters/in/web/UserDetailsServiceImpl.java
@@ -9,6 +9,8 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
+import java.util.UUID;
+
 @Component
 @Primary
 public class UserDetailsServiceImpl implements UserDetailsService {
@@ -22,7 +24,14 @@ public class UserDetailsServiceImpl implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         User user = userRepository.findByLogin(username)
-                .orElseThrow(() -> new UsernameNotFoundException("Usuário não encontrado"));
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        return UserDetailsImpl.build(user);
+    }
+
+    public UserDetails loadUserById(UUID id) throws UsernameNotFoundException {
+        User user = userRepository.findByIdOnly(id)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
 
         return UserDetailsImpl.build(user);
     }

--- a/src/main/java/com/fiap/techchallenge/infrastructure/adapters/out/persistence/DatabaseHealthChecker.java
+++ b/src/main/java/com/fiap/techchallenge/infrastructure/adapters/out/persistence/DatabaseHealthChecker.java
@@ -1,31 +1,17 @@
 package com.fiap.techchallenge.infrastructure.adapters.out.persistence;
 
-import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
 
 @Configuration
-@Profile("dev") // executa só no perfil dev
-public class DatabaseHealthChecker implements CommandLineRunner {
+public class DatabaseHealthChecker {
 
     private final DataSource dataSource;
 
     public DatabaseHealthChecker(DataSource dataSource) {
         this.dataSource = dataSource;
-    }
-
-    @Override
-    public void run(String... args) throws Exception {
-        try (Connection conn = dataSource.getConnection()) {
-            System.out.println(
-                    "\u001B[32m\uD83D\uDE80  🎉 Conexão bem-sucedida! URL: \u001B[0m" + conn.getMetaData().getURL());
-        } catch (Exception e) {
-            System.err.println("❌ Falha ao conectar: " + e.getMessage());
-            throw e;
-        }
     }
 
     public boolean isDatabaseUp() {

--- a/src/main/java/com/fiap/techchallenge/infrastructure/adapters/out/persistence/user/UserDataSource.java
+++ b/src/main/java/com/fiap/techchallenge/infrastructure/adapters/out/persistence/user/UserDataSource.java
@@ -62,6 +62,23 @@ public class UserDataSource implements UserRepository {
     }
 
     @Override
+    public Optional<User> findByIdOnly(UUID id) {
+        Optional<UserEntity> userEntity = jpaRepository.findById(id);
+        // Map only essential fields to avoid lazy loading issues
+        return userEntity.map(entity -> {
+            User user = new User();
+            user.setId(entity.getId());
+            user.setLogin(entity.getLogin());
+            user.setPassword(entity.getPassword());
+            user.setEmail(entity.getEmail());
+            user.setRole(entity.getRole());
+            user.setActive(entity.isActive());
+            // Do NOT set addressesList or any lazy collections
+            return user;
+        });
+    }
+
+    @Override
     public Optional<User> findByLogin(String login) {
         Optional<UserEntity> userEntity = jpaRepository.findByLogin(login);
 

--- a/src/main/java/com/fiap/techchallenge/infrastructure/config/JwtUtil.java
+++ b/src/main/java/com/fiap/techchallenge/infrastructure/config/JwtUtil.java
@@ -35,20 +35,20 @@ public class JwtUtil {
         try {
             return Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody();
         } catch (ExpiredJwtException ex) {
-            logger.warn("Token expirado ao extrair claims: {}", ex.getMessage());
+            logger.warn("Token expired while extracting claims: {}", ex.getMessage());
             throw ex;
         } catch (MalformedJwtException ex) {
-            logger.warn("Token malformado ao extrair claims: {}", ex.getMessage());
+            logger.warn("Malformed token while extracting claims: {}", ex.getMessage());
             throw ex;
         } catch (UnsupportedJwtException ex) {
-            logger.warn("Token não suportado ao extrair claims: {}", ex.getMessage());
+            logger.warn("Unsupported token while extracting claims: {}", ex.getMessage());
             throw ex;
         } catch (IllegalArgumentException ex) {
-            logger.warn("Token com argumento ilegal ao extrair claims: {}", ex.getMessage());
+            logger.warn("Illegal argument in token while extracting claims: {}", ex.getMessage());
             throw ex;
         } catch (Exception ex) {
-            logger.error("Erro inesperado ao extrair claims do token: {}", ex.getMessage(), ex);
-            throw new JwtException("Erro ao processar token", ex);
+            logger.error("Unexpected error while extracting claims from token: {}", ex.getMessage(), ex);
+            throw new JwtException("Error processing token", ex);
         }
     }
 
@@ -57,9 +57,15 @@ public class JwtUtil {
         return claims.getSubject();
     }
 
-    public String extractUserId(String token) {
+    public UUID extractUserId(String token) {
         Claims claims = extractAllClaims(token);
-        return claims.get("userId", String.class);
+        Object userIdObj = claims.get("userId");
+        if (userIdObj instanceof UUID) {
+            return (UUID) userIdObj;
+        } else if (userIdObj instanceof String) {
+            return UUID.fromString((String) userIdObj);
+        }
+        throw new JwtException("Invalid userId claim type");
     }
 
     public String extractEmail(String token) {
@@ -72,31 +78,30 @@ public class JwtUtil {
             Jwts.parser().setSigningKey(secret).parseClaimsJws(token);
             return true;
         } catch (ExpiredJwtException ex) {
-            logger.warn("Token expirado: {}", ex.getMessage());
+            logger.warn("Token expired: {}", ex.getMessage());
             throw ex;
         } catch (MalformedJwtException ex) {
-            logger.warn("Token malformado: {}", ex.getMessage());
+            logger.warn("Malformed token: {}", ex.getMessage());
             throw ex;
         } catch (UnsupportedJwtException ex) {
-            logger.warn("Token não suportado: {}", ex.getMessage());
+            logger.warn("Unsupported token: {}", ex.getMessage());
             throw ex;
         } catch (IllegalArgumentException ex) {
-            logger.warn("Token com argumento ilegal: {}", ex.getMessage());
+            logger.warn("Illegal argument in token: {}", ex.getMessage());
             throw ex;
         } catch (Exception ex) {
-            logger.error("Erro inesperado ao validar token: {}", ex.getMessage(), ex);
-            throw new JwtException("Erro ao validar token", ex);
+            logger.error("Unexpected error while validating token: {}", ex.getMessage(), ex);
+            throw new JwtException("Error validating token", ex);
         }
     }
 
     public boolean isTokenExpired(String token) {
         try {
             Claims claims = Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody();
-
             return claims.getExpiration().before(new Date());
         } catch (Exception ex) {
-            logger.warn("Erro ao verificar expiração do token: {}", ex.getMessage());
-            return true; // Considera como expirado em caso de erro
+            logger.warn("Error checking token expiration: {}", ex.getMessage());
+            return true;
         }
     }
 }

--- a/src/main/java/com/fiap/techchallenge/infrastructure/config/JwtUtil.java
+++ b/src/main/java/com/fiap/techchallenge/infrastructure/config/JwtUtil.java
@@ -20,10 +20,15 @@ public class JwtUtil {
     @Value("${jwt.expiration-ms}")
     private long expMs;
 
-    public String generateToken(String username, UUID userId, String email) {
+    public String generateToken(UUID userId, String role) {
         Date now = new Date();
-        return Jwts.builder().setSubject(username).claim("userId", userId).claim("email", email).setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + expMs)).signWith(SignatureAlgorithm.HS256, secret).compact();
+        return Jwts.builder()
+                .claim("userId", userId)
+                .claim("role", role)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + expMs))
+                .signWith(SignatureAlgorithm.HS256, secret)
+                .compact();
     }
 
     public Claims extractAllClaims(String token) {


### PR DESCRIPTION
This PR resolves the following issues:

#78: JWT token now only includes userId and role, not login or email. This prevents the need to re-authenticate when login is changed.
#76, #71, #70: User access is now restricted so only the logged-in user can update, delete, or view their own data. OWNER users can see themselves and all CUSTOMERS; CUSTOMER users can only see themselves.
Details:

Updated JwtUtil and AuthUseCaseImpl to remove login/email from token claims.
Updated controllers to enforce user access rules.

#58